### PR TITLE
Adding ability to block only specific URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-Author:
-Rahul Gupta-Iwasaki 
+Authors:
+Rahul Gupta-Iwasaki
+Mukil Kesavan
 
 License:
 See "LICENSE" file.
 
 README:
 
-This is a very simple extension for Google Chrome. When you find yourself on a website that is taking too much of your time, simply hit the Blacklist button in the upper right corner of Chrome and you will be blocked from visiting that site while Blacklist remains active. To resume visiting any site blocked by Blacklist, you must visit the site, click the Blacklist extension button in the upper right corner of the browser, and then click the "unlist" button. You will be forced to wait for 15 seconds before the site is unlisted and you are redirected to the root url.
+This is a very simple extension for Google Chrome. When you find yourself on a website that is taking too much of your time, simply hit the Blacklist button in the upper right corner of Chrome and choose between blocking the entire domain or just the current URL (i.e., some sub-page). You will be blocked from visiting that domain or sub-page url while Blacklist remains active. To resume visiting any site or sub-page url blocked by Blacklist, you must visit the site, click the Blacklist extension button in the upper right corner of the browser, and then click the "unlist site" or "unlist url" button. If you chose "unlist site" then ALL restrictions for the entire domain will be lifted. If you chose "unlist url" and you had originally blocked only the current sub-age URL, then only the current sub-age restrictions will be removed. However, if you had blocked the entire domain, then the domain restrictions will be removed when you choose "unlist url". Note that you will be forced to wait for 15 seconds before any restrictions are removed and you will be redirected to the root url.
  
 This extension is released for free in and can be installed directly from the Chrome store at https://chrome.google.com/webstore/detail/blacklist/jbpccandodannohfaoncogijbkfcmpgo?hl=en&gl=US.
 Alternatively, to install this extension directly from the source, download the code from GitHub, extract it, and then add it to Chrome as detailed in step 4 of Create and Load Extensions on this page: http://developer.chrome.com/extensions/getstarted.html.

--- a/js/background.js
+++ b/js/background.js
@@ -1,28 +1,74 @@
 var blockedSites = [];
+var blockedUrls = [];
 var tabBlockingMap = {};
 
-chrome.storage.local.get("blocked", function(items) {
-  if (items.blocked)
-    blockedSites = items.blocked;
+chrome.storage.local.get("blockedSites", function(items) {
+  if (items.blockedSites)
+    blockedSites = items.blockedSites;
 });
 
-function addBlockedSite(tabid, blockedSite) {
-  blockedSites.push(blockedSite);
-  tabBlockingMap[tabid] = blockedSite;
+chrome.storage.local.get("blockedUrls", function(items) {
+  if (items.blockedUrls)
+    blockedUrls = items.blockedUrls;
+});
+
+function addBlockedSiteOrUrl(tabid, blocked, isSite) {
+  if (isSite) {
+    blockedSites.push(blocked);
+  } else {
+    blockedUrls.push(blocked);
+  }
+  tabBlockingMap[tabid] = blocked;
 }
 
-function unlistSite(tabid, site) {
-  var i = blockedSites.indexOf(site);
-  if (i > -1)
-    blockedSites.splice(i, 1);
-  chrome.storage.local.set( {blocked: blockedSites}, function() {
-    console.log("Site Unlisted");
+function extract_url_domain(data) {
+  var a = document.createElement('a');
+  a.href = data;
+  return a.hostname;
+}
+
+function findInList(list, urlstr, partialMatch) {
+  var matched_indices = [];
+  if (!partialMatch) {
+    var i = list.indexOf(urlstr);
+    if (i >= 0) {
+      matched_indices.push(i);
+    }
+    return matched_indices;
+  }
+  var rootUrl = extract_url_domain(urlstr);
+  for (var i = 0; i < list.length; ++i) {
+    if (list[i].match(rootUrl)) {
+      matched_indices.push(i);
+    }
+  }
+  return matched_indices;
+}
+
+function unlist(blockedList, curUrl, blockedType, isSite) {
+  var matched_indices = findInList(blockedList, curUrl, isSite);
+  console.log("found " + matched_indices.length + " matches for " + curUrl);
+  for (var i = matched_indices.length - 1; i >= 0; --i) {
+    blockedList.splice(matched_indices[i], 1);
+  }
+  var storedict = {};
+  storedict[blockedType] = blockedList;
+  chrome.storage.local.set(storedict, function() {
+    console.log("Site or url(s) Unlisted");
   });
+}
+
+function unlistSiteOrUrl(tabid, curUrl, isSite) {
+  //we only have to partial match urls if user clicked remove site
+  unlist(blockedUrls, curUrl, "blockedUrls", isSite);
+  //we never have to partial match while checking blocked sites
+  unlist(blockedSites, curUrl, "blockedSites", false);
   tabBlockingMap[tabid] = 0;
 }
 
 function clearBlacklist() {
   blockedSites = [];
+  blockedUrls = [];
   tabBlockingMap = {};
 }
 
@@ -40,6 +86,15 @@ function requestChecker(request) {
         if (request.url.match(new RegExp(
             ".*" + blockedSites[i] + ".*", "i"))) {
           tabBlockingState = blockedSites[i];
+          console.log("found " + request.url + " in blocked sites");
+        }
+      }
+      if (tabBlockingState == 0) {
+        for (var i = 0; i < blockedUrls.length; ++i) {
+         if (request.url.toLowerCase() == blockedUrls[i].toLowerCase()) {
+          tabBlockingState = blockedUrls[i];
+          console.log("found " + request.url + " in blocked urls");
+         }
         }
       }
       chrome.tabs.getSelected(null, function(tab) {

--- a/js/blockedSite.js
+++ b/js/blockedSite.js
@@ -4,24 +4,23 @@ site = site.substring(site.indexOf("=") + 1);
 $("#blockMessage").text(site + " has been Blacklisted.");
 
 var content = $("#countdown");
-var i = 15;
+var UNLOCK_INTERVAL = 15;
 var interval = 0;
 
-function updateCountdown() {
-  content.text("Unlisting " + site + " in " + --i + " seconds...");
-  if (i == 0) {
-    clearInterval(interval);
-    chrome.tabs.getCurrent(function(tab) {
-      chrome.extension.getBackgroundPage().unlistSite(tab.id, site);
-    });
-    window.location = site;
-  }
-}
-
-function beginCountdown() {
-  i = 15;
-  content.text("Unlisting " + site + " in " + i + " seconds...");
-  interval = setInterval(function() {updateCountdown(i)}, 1000);
+function beginCountdown(isSite) {
+  var i = UNLOCK_INTERVAL;
+  var unlistType = (isSite)? "entire site": "url";
+  content.text("Unlisting " + unlistType + " in " + i + " seconds...");
+  interval = setInterval(function() {
+    content.text("Unlisting " + unlistType + " in " + --i + " seconds...");
+    if (i == 0) {
+      clearInterval(interval);
+      chrome.tabs.getCurrent(function(tab) {
+        chrome.extension.getBackgroundPage().unlistSiteOrUrl(tab.id, site, isSite);
+      });
+      window.location = site;
+    }
+  }, 1000);
 }
 
 function modalHidden() {
@@ -36,12 +35,13 @@ $("#unlistModal").on('hidden', modalHidden);
 $("#cancelUnlist").click(hideModal);
 
 chrome.extension.onMessage.addListener(
-    function(message, sender, sendResponse) {
-  chrome.tabs.getCurrent(function(tab) {
-    if (tab.id == message) {
-      $("#unlistModal").modal("show");
-      beginCountdown();
-    }
-  });
-});
+  function(request, sender, sendResponse) {
+    chrome.tabs.getCurrent(function(tab) {
+      if (tab.id == request.tabid) {
+        $("#unlistModal").modal("show");
+        beginCountdown(request.isSite);
+      }
+    });
+  }
+);
 

--- a/js/contentScript.js
+++ b/js/contentScript.js
@@ -9,6 +9,6 @@ chrome.extension.onMessage.addListener(
     sendResponse( {URL: document.URL} );
   else if (request.action == "redirect") {
     window.location = chrome.extension.getURL(
-      "blockedSite.html?blocked=" + request.blockedSite);
+      "blockedSite.html?blocked=" + request.blocked);
   }
 });

--- a/popup.html
+++ b/popup.html
@@ -12,7 +12,8 @@
   <div class="container">
     <hr class="featurette-divider">
     <div class="featurette" id="main-container">
-      <button class="btn" id="blacklistButton" ></button>
+      <button class="btn" id="blacklistSiteButton" ></button>
+      <button class="btn" id="blacklistUrlButton" ></button>
     </div>
     <hr class="featurette-divider">
   </div>


### PR DESCRIPTION
Hi Rahul,

I extended your extension to block only specific URLs instead of the entire domain. For example, when I block - http://www.reddit.com/r/videos, and then visit - http://www.reddit.com/r/nfl - I should be allowed to visit the page. I've added a new button to the popup page for blocking just the current URL. I've updated the description to describe how the two buttons behave for blacklisted and non-blacklisted pages.

Cheers,
Mukil

